### PR TITLE
Update to Semantic UI 2.4

### DIFF
--- a/semantic/forms.py
+++ b/semantic/forms.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from django import forms
+
+from crispy_forms.bootstrap import AppendedText, FormActions, PrependedText
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Div, Submit, HTML, Button, Row, Field
-from crispy_forms.bootstrap import AppendedText, PrependedText, FormActions
+from crispy_forms.layout import HTML, Button, Div, Field, Layout
+from crispy_forms_semantic_ui.semantic import StrictButton
 
 
 class MessageForm(forms.Form):
@@ -49,8 +51,8 @@ class MessageForm(forms.Form):
         'radio_buttons',
         Field('checkboxes', style="background: #FAFAFA"),
         FormActions(
-            Submit('save_changes', 'Save changes', css_class="btn-primary"),
-            Submit('cancel', 'Cancel'),
+            StrictButton('Save changes'),
+            StrictButton('Cancel'),
         )
     )
 
@@ -102,7 +104,7 @@ class HorizontalMessageForm(forms.Form):
         choices=(('1', '1'), ('2', '2'), ('3', '3'), ('4', '4'), ('5', '5')),
     )
 
-    # Bootstrap4
+    # Semantic UI
     helper = FormHelper()
     helper.layout = Layout(
         Field('text_input'),
@@ -110,17 +112,17 @@ class HorizontalMessageForm(forms.Form):
         'radio_buttons',
         Field('checkboxes'),
         AppendedText('appended_text', '.00'),
-        AppendedText('appended_text2', '.00', css_class='form-control-lg'),
+        AppendedText('appended_text2', '.00'),
         PrependedText('prepended_text',
-                      '<input type="checkbox" checked="checked" value="" id="" name="">',
+                      '<i class="tags icon"></i>',
                       active=True),
         PrependedText('prepended_text_two', '@'),
         'multicolon_select',
         FormActions(
-            Submit('save_changes', 'Save changes', css_class="btn-primary"),
-            Submit('cancel', 'Cancel'),
+            StrictButton('Save changes'),
+            StrictButton('Cancel')
         )
     )
 
     helper.label_class = ''
-    helper.field_class = 'six wide field'
+    helper.field_class = ''

--- a/semantic/templates/semantic/base.html
+++ b/semantic/templates/semantic/base.html
@@ -1,3 +1,4 @@
+{% load i18n static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <!-- Semantic UI CSS -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/semantic-ui/2.1.8/semantic.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.1/dist/semantic.min.css">
 </head>
 <body>
 <div class="page-wrap">
@@ -15,7 +16,9 @@
     {% endblock %}
 </div>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/semantic-ui/2.1.8/semantic.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.1/dist/semantic.min.js"></script>
+<script src="{% static "semantic-ui/js/semantic-loader.js" %}"></script>
+</script>
 </body>
 </html>

--- a/semantic/templates/semantic/index.html
+++ b/semantic/templates/semantic/index.html
@@ -3,8 +3,8 @@
 
 {% block content %}
 <div class="ui inverted segment">
-    <div class="ui inverted secondary pointing text menu">
-        <div class="header item">Crispy Test Project</div>
+    <div class="ui inverted text menu">
+        <div style="color: white;" class="header item">Crispy Test Project</div>
         <a class="item" href="{% url 'bootstrap3.views.index' %}">Bootstrap 3</a>
         <a class="item" href="{% url 'bootstrap4.views.index' %}">Bootstrap 4</a>
         <a class="active item" href="{% url 'semantic.views.index' %}"><i class="selected radio icon"></i> Semantic UI</a>

--- a/semantic/views.py
+++ b/semantic/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render
 
 
 def index(request):
-    #settings.CRISPY_TEMPLATE_PACK = 'semantic_ui'
+    settings.CRISPY_TEMPLATE_PACK = 'semantic-ui'
     from semantic.forms import HorizontalMessageForm, MessageForm
 
     # This view is missing all form handling logic for simplicity of the example


### PR DESCRIPTION
Related to pull request https://github.com/acidjunk/crispy-forms-semanticUI-templates/pull/8 Appearance of semantic-ui template package is improved in crispy-test-project.

Please be patient until "Update to Semantic UI 2.3, Django 1.11, Cripsy forms 1.7" https://github.com/acidjunk/crispy-forms-semanticUI-templates/issues/7 issue is closed.

When pull requests are resolved, I am interested in contributing to "Document all official and third party template packs" https://github.com/django-crispy-forms/django-crispy-forms/issues/626