### PR TITLE
remove SessionAuthenticationMiddleware

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f12cf3a2d686e6c021ea1825f1675aba839be36131baca8a448152760444ca94"
+            "sha256": "7bf9d720e65a749550951d9d23ed984b5d6294f2326fc5d2b7364a2489c682a7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:1a41831eace203fd1939edf899e07d7abd12ce9bafc3d9a5a63a24a8d1d12bd5",
-                "sha256:305b6c4fce9e03bb746e35780c2c4d52f29ea1669f15633cfd41bc8821c74c76"
+                "sha256:148a4a2d1a85b23883b0a4e99ab7718f518a83675e4485e44dc0c1d36988c5fa",
+                "sha256:deb70aa038e59b58593673b15e9a711d1e5ccd941b5973b30750d5d026abfd56"
             ],
             "index": "pypi",
-            "version": "==2.1.11"
+            "version": "==2.2.5"
         },
         "django-crispy-forms": {
             "hashes": [
@@ -50,11 +50,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
-                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
+                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
+                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
             ],
             "index": "pypi",
-            "version": "==2018.5"
+            "version": "==2019.2"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+            ],
+            "version": "==0.3.0"
         }
     },
     "develop": {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 crispy-forms-semantic-ui==0.2.0
 django-crispy-forms==1.7.2
-django==2.1.11
+Django==2.2.5
 gunicorn==19.9.0
 pytz==2018.5

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -54,7 +54,6 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
This PR Fixes #11. This was quite a simple fix; just needed to remove `SessionAuthenticationMiddleware` from settings.py.

I've tested this on both django v.2.2 and v.2.1 and it works on both. 

I've also updated the requirements.txt /pip.lock file to match the configuration when you run `pipenv install`.



I considered introducing tests with this PR, but thought it's best to keep the changes separate. Do you think it's worth adding a small test file so Travis CI could give some assurance? I'm thinking just check a valid response code is generated for the main pages?