### PR TITLE
Limit the highest supported version of django-crispy-forms

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,7 +3,7 @@ python_version = "3.8"
 
 [packages]
 # Use pip install -e ../django-crispy-forms for local dev
-django-crispy-forms = ">=1.8.1"
+django-crispy-forms = ">=1.8.1, <2.0"
 gunicorn = ">=20.0.4"
 pytz = ">=2019.3"
 # added to ease up testing of semantic ui templates

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-crispy-forms-semantic-ui>=0.2.0 # added to ease up testing of semantic ui templates
-django-crispy-forms>=1.9.0      # Use pip install -e ../django-crispy-forms for local dev
+crispy-forms-semantic-ui>=0.2.0   # added to ease up testing of semantic ui templates
+django-crispy-forms>=1.9.0, <2.0  # Use pip install -e ../django-crispy-forms for local dev
 Django>=3.0.7
 gunicorn>=20.0.4
 pytz>=2019.3


### PR DESCRIPTION
This PR fix issue #34
I've add limit for django-crispy-forms lib in requirements.txt and Pipfile